### PR TITLE
prove_inclusion_by_index

### DIFF
--- a/pymerkle/tree/base.py
+++ b/pymerkle/tree/base.py
@@ -153,6 +153,24 @@ class BaseMerkleTree(HashEngine, metaclass=ABCMeta):
         proof = self.build_proof(offset, path)
         return proof
 
+    def prove_inclusion_at(self, offset):
+        """
+        Prove inclusion of the entry at the provided position
+
+        :param offset: position of the entry to prove inclusion of
+        :type offset: int
+        :rtype: MerkleProof
+        :raises InvalidChallenge: if the provided position is out of bounds
+        """
+        if offset >= self.length:
+            raise InvalidChallenge("Provided offset is out of bounds")
+
+        leaf = self.leaf(offset)
+        offset, path = self.generate_inclusion_path(leaf)
+
+        proof = self.build_proof(offset, path)
+        return proof
+    
     @abstractmethod
     def generate_consistency_path(self, sublength):
         """


### PR DESCRIPTION
Would it be possible to insert this method? It may be useful for the user to choose the way to access the proof. In addition, accessing the index can improve performance depending on the size of the tree.

Currently it is possible to get the proof object by the index like this:

```
leaf = tree.get_leaf(leaf_index)
offset, path = tree.generate_inclusion_path(leaf)
proof = tree.build_proof(offset, path)

# replace for 
# proof = tree.prove_inclusion_at(leaf_index)
```

It works, but it would be interesting to include this in a method.