### PR TITLE
Added typing to improve the use of the library (#1)

### DIFF
--- a/benchmarks/conftest.py
+++ b/benchmarks/conftest.py
@@ -1,46 +1,51 @@
-import os
 import math
+import os
+from typing import Final
+
 import pytest
 
-from pymerkle import SqliteTree as MerkleTree, constants
+from pymerkle import SqliteTree as MerkleTree
+from pymerkle import constants
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
+current_dir: str = os.path.dirname(os.path.abspath(__file__))
 
-DEFAULT_DB = os.path.join(current_dir, 'merkle.db')
-DEFAULT_SIZE = 10 ** 6
-DEFAULT_INDEX = math.ceil(DEFAULT_SIZE / 2)
-DEFAULT_ROUNDS = 100
-DEFAULT_THRESHOLD = 128
-DEFAULT_CAPACITY = 1024 ** 3
+DEFAULT_DB: Final[str] = os.path.join(current_dir, 'merkle.db')
+DEFAULT_SIZE: Final[int] = 10 ** 6
+DEFAULT_INDEX: Final[int] = math.ceil(DEFAULT_SIZE / 2)
+DEFAULT_ROUNDS: Final[int] = 100
+DEFAULT_THRESHOLD: Final[int] = 128
+DEFAULT_CAPACITY: Final[int] = 1024 ** 3
 
 
 def pytest_addoption(parser):
     parser.addoption('--dbfile', type=str, default=DEFAULT_DB,
-        help='Database filepath')
+                     help='Database filepath')
     parser.addoption('--size', type=int, default=DEFAULT_SIZE,
-        help='Nr entries to consider')
+                     help='Nr entries to consider')
     parser.addoption('--index', type=int, default=DEFAULT_INDEX,
-        help='Base index for proof operations')
+                     help='Base index for proof operations')
     parser.addoption('--rounds', type=int, default=DEFAULT_ROUNDS,
-        help='Nr rounds per benchmark')
+                     help='Nr rounds per benchmark')
     parser.addoption('--algorithm', default='sha256',
-        choices=constants.ALGORITHMS,
-        help='Hash algorithm used by the tree')
+                     choices=constants.ALGORITHMS,
+                     help='Hash algorithm used by the tree')
     parser.addoption('--randomize', action='store_true', default=False,
-        help='Randomize function input per round')
+                     help='Randomize function input per round')
     parser.addoption('--disable-optimizations', action='store_true', default=False,
-        help='Use unoptimized versions of core operations')
+                     help='Use unoptimized versions of core operations')
     parser.addoption('--disable-cache', action='store_true', default=False,
-        help='Disable subroot caching')
+                     help='Disable subroot caching')
     parser.addoption('--threshold', type=int, metavar='WIDTH',
-        default=DEFAULT_THRESHOLD,
-        help='Subroot cache threshold')
+                     default=DEFAULT_THRESHOLD,
+                     help='Subroot cache threshold')
     parser.addoption('--capacity', type=int, metavar='BYTES',
-        default=DEFAULT_CAPACITY,
-        help='Subroot cache capacity in bytes')
+                     default=DEFAULT_CAPACITY,
+                     help='Subroot cache capacity in bytes')
+
 
 option = None
 
-def pytest_configure(config):
+
+def pytest_configure(config) -> None:
     global option
     option = config.option

--- a/benchmarks/init_db.py
+++ b/benchmarks/init_db.py
@@ -3,47 +3,48 @@ Create tree sqlite database for benchmarking. WARNING: Unless otherwise specifie
 the database file will be overwritten if it already exists.
 """
 
+import argparse
 import os
 import sys
-import argparse
 import time
+from typing import Any, Final
 
 from pymerkle import SqliteTree, constants
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
+current_dir: str = os.path.dirname(os.path.abspath(path=__file__))
 
-DEFAULT_DB = os.path.join(current_dir, 'merkle.db')
-DEFAULT_ALGORITHM = 'sha256'
-DEFAULT_SIZE = 10 ** 8
-DEFAULT_BATCHSIZE = 10 ** 7
+DEFAULT_DB: Final[str] = os.path.join(current_dir, 'merkle.db')
+DEFAULT_ALGORITHM: Final[str] = 'sha256'
+DEFAULT_SIZE: Final[int] = 10 ** 8
+DEFAULT_BATCHSIZE: Final[int] = 10 ** 7
 
 
-def parse_cli_args():
-    config = {'prog': sys.argv[0], 'usage': 'python %s' % sys.argv[0],
-              'description': __doc__, 'epilog': '\n',
-              'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
+def parse_cli_args() -> argparse.Namespace:
+    config: dict[str, Any] = {'prog': sys.argv[0], 'usage': 'python %s' % sys.argv[0],
+                              'description': __doc__, 'epilog': '\n',
+                              'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
     parser = argparse.ArgumentParser(**config)
 
     parser.add_argument('--dbfile', type=str, default=DEFAULT_DB,
-        help='Database filepath')
+                        help='Database filepath')
     parser.add_argument('--algorithm', choices=constants.ALGORITHMS,
-        default=DEFAULT_ALGORITHM, help='Hashing algorithm')
+                        default=DEFAULT_ALGORITHM, help='Hashing algorithm')
     parser.add_argument('--disable-security', action='store_true', default=False,
-        help='Disable resistance against 2nd-preimage attack')
+                        help='Disable resistance against 2nd-preimage attack')
     parser.add_argument('--size', type=int, default=DEFAULT_SIZE,
-        help='Nr entries to append in total')
+                        help='Nr entries to append in total')
     parser.add_argument('--batchsize', type=int, default=DEFAULT_BATCHSIZE,
-        help='Nr entries to append per bulk insertion')
+                        help='Nr entries to append per bulk insertion')
     parser.add_argument('--preserve-database', action='store_true', default=False,
-        help='Append without overwriting if already existent')
+                        help='Append without overwriting if already existent')
 
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    args = parse_cli_args()
+    args: argparse.Namespace = parse_cli_args()
 
-    batchsize = args.batchsize
+    batchsize = int(args.batchsize)
     size = args.size
     if batchsize > size:
         sys.stdout.write("[-] Batchsize exceeds size\n")
@@ -51,29 +52,31 @@ if __name__ == '__main__':
 
     if not args.preserve_database:
         try:
-            os.remove(args.dbfile)
+            os.remove(path=args.dbfile)
         except OSError:
             pass
 
-    opts = {'algorithm': args.algorithm,
-            'disable_security': args.disable_security}
+    opts: dict[str, Any] = {'algorithm': args.algorithm,
+                            'disable_security': args.disable_security}
 
-    with SqliteTree(args.dbfile, **opts) as tree:
-        offset = 0
-        count = 1
+    with SqliteTree(dbfile=args.dbfile, **opts) as tree:
+        offset: int = 0
+        count: int = 1
         append_entries = tree.append_entries
-        chunksize = min(100_000, batchsize)
-        start_time = time.time()
+        chunksize: int = min(100_000, batchsize)
+        start_time: float = time.time()
+        currsize: int = 0
         while offset < size:
-            limit = offset + batchsize + 1
+            limit: int = offset + batchsize + 1
             if limit > size + 1:
                 limit = size + 1
 
             print(f"\nCreating {batchsize} entries...")
-            entries = [f'entry-{i}'.encode('utf-8') for i in range(offset + 1,
-                limit)]
+            entries: list[bytes] = [f'entry-{i}'.encode(encoding='utf-8') for i in range(offset + 1,
+                                                                                         limit)]
 
-            index = append_entries(entries, chunksize)
+            index: int = append_entries(
+                entries=entries, chunksize=chunksize)  # type: ignore
             assert index == limit - 1
 
             currsize = tree.get_size()
@@ -83,8 +86,8 @@ if __name__ == '__main__':
             count += 1
             offset += batchsize
 
-        end_time = time.time()
-        elapsed_time = end_time - start_time
+        end_time: float = time.time()
+        elapsed_time: float = end_time - start_time
 
         assert currsize == args.size
 

--- a/benchmarks/test_perf.py
+++ b/benchmarks/test_perf.py
@@ -1,21 +1,24 @@
 from random import randint
+from typing import Any
+
 import pytest
 
 from pymerkle import SqliteTree as MerkleTree
+
 from .conftest import option
 
-defaults = {'warmup_rounds': 0, 'rounds': option.rounds}
+defaults: dict[str, Any] = {'warmup_rounds': 0, 'rounds': option.rounds}
 
 
-opts = {'disable_optimizations': option.disable_optimizations,
-        'disable_cache': option.disable_cache,
-        'threshold': option.threshold,
-        'capacity': option.capacity}
+opts: dict[str, Any] = {'disable_optimizations': option.disable_optimizations,
+                        'disable_cache': option.disable_cache,
+                        'threshold': option.threshold,
+                        'capacity': option.capacity}
 
-tree = MerkleTree(option.dbfile, algorithm=option.algorithm, **opts)
+tree = MerkleTree(dbfile=option.dbfile, algorithm=option.algorithm, **opts)
 
 
-def test_root(benchmark):
+def test_root(benchmark) -> None:
 
     def setup():
         start = randint(0, option.size - 2) if option.randomize else 0
@@ -27,7 +30,7 @@ def test_root(benchmark):
     benchmark.pedantic(tree._get_root, setup=setup, **defaults)
 
 
-def test_state(benchmark):
+def test_state(benchmark) -> None:
 
     def setup():
         size = randint(1, option.size) if option.randomize \
@@ -38,7 +41,7 @@ def test_state(benchmark):
     benchmark.pedantic(tree.get_state, setup=setup, **defaults)
 
 
-def test_inclusion(benchmark):
+def test_inclusion(benchmark) -> None:
 
     def setup():
         size = option.size
@@ -49,7 +52,7 @@ def test_inclusion(benchmark):
     benchmark.pedantic(tree.prove_inclusion, setup=setup, **defaults)
 
 
-def test_consistency(benchmark):
+def test_consistency(benchmark) -> None:
 
     def setup():
         size2 = option.size

--- a/demo.py
+++ b/demo.py
@@ -29,19 +29,19 @@ def parse_cli_args():
     parser = argparse.ArgumentParser(**config)
 
     parser.add_argument('--backend', choices=['inmemory', 'sqlite'],
-            default='inmemory', help='Storage backend')
+                        default='inmemory', help='Storage backend')
     parser.add_argument('--algorithm', choices=constants.ALGORITHMS,
-            default='sha256', help='Hashing algorithm')
+                        default='sha256', help='Hashing algorithm')
     parser.add_argument('--threshold', type=int, metavar='WIDTH',
-            default=128, help='Subroot cache threshold')
+                        default=128, help='Subroot cache threshold')
     parser.add_argument('--capacity', type=int, metavar='MAXSIZE',
-            default=1024 ** 3, help='Subroot cache capacity in bytes')
+                        default=1024 ** 3, help='Subroot cache capacity in bytes')
     parser.add_argument('--disable-security', action='store_true',
-            default=False, help='Disable resistance against second-preimage attack')
+                        default=False, help='Disable resistance against second-preimage attack')
     parser.add_argument('--disable-optimizations', action='store_true',
-            default=False, help='Use unopmitized versions of core operations')
+                        default=False, help='Use unopmitized versions of core operations')
     parser.add_argument('--disable-cache', action='store_true',
-            default=False, help='Disable subroot caching')
+                        default=False, help='Disable subroot caching')
 
     return parser.parse_args()
 
@@ -50,7 +50,7 @@ def order_of_magnitude(num):
     return int(log10(num)) if not num == 0 else 0
 
 
-def strpath(rule, path):
+def strpath(rule, path) -> str:
     s2 = 3 * ' '
     s3 = 3 * ' '
     template = '\n{s1}[{index}]{s2}{bit}{s3}{value}'
@@ -65,16 +65,16 @@ def strpath(rule, path):
     return ''.join(pairs)
 
 
-def strtree(tree):
+def strtree(tree) -> str:
     if isinstance(tree, SqliteTree):
         entries = [tree.get_entry(index) for index in range(1, tree.get_size()
-            + 1)]
+                                                            + 1)]
         tree = InmemoryTree.init_from_entries(entries)
 
     return str(tree)
 
 
-def strproof(proof):
+def strproof(proof) -> str:
     template = """
     algorithm   : {algorithm}
     security    : {security}
@@ -98,7 +98,7 @@ def strproof(proof):
 if __name__ == '__main__':
     args = parse_cli_args()
 
-    MerkleTree = { 'inmemory': InmemoryTree, 'sqlite': SqliteTree }[
+    MerkleTree = {'inmemory': InmemoryTree, 'sqlite': SqliteTree}[
         args.backend]
 
     config = {'algorithm': args.algorithm,

--- a/profiler/__main__.py
+++ b/profiler/__main__.py
@@ -2,112 +2,113 @@
 Run tree operations for profiling purposes
 """
 
+import argparse
 import os
 import sys
-import argparse
 from random import randint
+from typing import Any, Final
 
 from pymerkle import SqliteTree as MerkleTree
 from pymerkle import constants
 
-current_dir = os.path.dirname(os.path.abspath(__file__))
-parent_dir = os.path.dirname(current_dir)
+current_dir: str = os.path.dirname(os.path.abspath(__file__))
+parent_dir: str = os.path.dirname(current_dir)
 
-DEFAULT_DB = os.path.join(parent_dir, 'benchmarks', 'merkle.db')
-DB_SIZE = 10 ** 6
-DEFAULT_ROUNDS = 1
-DEFAULT_THRESHOLD = 128
-DEFAULT_CAPACITY = 1024 ** 3
+DEFAULT_DB: Final[str] = os.path.join(parent_dir, 'benchmarks', 'merkle.db')
+DB_SIZE: Final[int] = 10 ** 6
+DEFAULT_ROUNDS: Final[int] = 1
+DEFAULT_THRESHOLD: Final[int] = 128
+DEFAULT_CAPACITY: Final[int] = 1024 ** 3
 
 
-def parse_cli_args():
-    config = {'prog': sys.argv[0], 'usage': 'python %s' % sys.argv[0],
-              'description': __doc__, 'epilog': '\n',
-              'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
+def parse_cli_args() -> argparse.Namespace:
+    config: dict[str, Any] = {'prog': sys.argv[0], 'usage': 'python %s' % sys.argv[0],
+                              'description': __doc__, 'epilog': '\n',
+                              'formatter_class': argparse.ArgumentDefaultsHelpFormatter}
     parser = argparse.ArgumentParser(**config)
 
     parser.add_argument('--dbfile', type=str, default=DEFAULT_DB,
-        help='Database filepath')
+                        help='Database filepath')
     parser.add_argument('--algorithm', choices=constants.ALGORITHMS,
-        default='sha256', help='Hashing algorithm')
+                        default='sha256', help='Hashing algorithm')
     parser.add_argument('--rounds', type=int, default=DEFAULT_ROUNDS,
-        help='Nr rounds')
+                        help='Nr rounds')
     parser.add_argument('--randomize', action='store_true', default=False,
-        help='Randomize function input per round')
+                        help='Randomize function input per round')
     parser.add_argument('--disable-optimizations', action='store_true', default=False,
-        help='Use unoptimized versions of core functionalities')
+                        help='Use unoptimized versions of core functionalities')
     parser.add_argument('--disable-cache', action='store_true', default=False,
-        help='Disable subroot caching')
+                        help='Disable subroot caching')
     parser.add_argument('--threshold', type=int, metavar='WIDTH',
-        default=DEFAULT_THRESHOLD, 
-        help='Subroot cache threshold')
+                        default=DEFAULT_THRESHOLD,
+                        help='Subroot cache threshold')
     parser.add_argument('--capacity', type=int, metavar='BYTES',
-        default=DEFAULT_CAPACITY,
-        help='Subroot cache capacity in bytes')
+                        default=DEFAULT_CAPACITY,
+                        help='Subroot cache capacity in bytes')
 
     operation = parser.add_subparsers(dest='operation')
 
-    root = operation.add_parser('root',
-        help='Run `_get_root`')
+    root: argparse.ArgumentParser = operation.add_parser('root',
+                                                         help='Run `_get_root`')
     root.add_argument('--start', type=int, default=0,
-        help='Starting position')
+                      help='Starting position')
     root.add_argument('--limit', type=int, default=DB_SIZE,
-        help='Final position')
+                      help='Final position')
 
-    state = operation.add_parser('state',
-        help='Run `get_state`')
+    state: argparse.ArgumentParser = operation.add_parser('state',
+                                                          help='Run `get_state`')
     state.add_argument('--size', type=int, default=DB_SIZE,
-        help='Nr entries to consider')
+                       help='Nr entries to consider')
 
-    inclusion = operation.add_parser('inclusion',
-        help='Run `prove_inclusion`')
+    inclusion: argparse.ArgumentParser = operation.add_parser('inclusion',
+                                                              help='Run `prove_inclusion`')
     inclusion.add_argument('--index', type=int, required=True,
-        help='Leaf index')
+                           help='Leaf index')
     inclusion.add_argument('--size', type=int, default=DB_SIZE,
-        help='Nr entries to consider')
+                           help='Nr entries to consider')
 
-    consistency = operation.add_parser('consistency',
-        help='Run `prove_consistency`')
+    consistency: argparse.ArgumentParser = operation.add_parser('consistency',
+                                                                help='Run `prove_consistency`')
     consistency.add_argument('--size1', type=int, required=True,
-        help='Size of prior state')
+                             help='Size of prior state')
     consistency.add_argument('--size2', type=int, default=DB_SIZE,
-        help='Size of later state')
+                             help='Size of later state')
 
     return parser.parse_args()
 
 
 if __name__ == '__main__':
-    cli = parse_cli_args()
+    cli: argparse.Namespace = parse_cli_args()
 
-    opts = {'disable_optimizations': cli.disable_optimizations,
-            'disable_cache': cli.disable_cache,
-            'threshold': cli.threshold,
-            'capacity': cli.capacity}
+    opts: dict[str, Any] = {'disable_optimizations': cli.disable_optimizations,
+                            'disable_cache': cli.disable_cache,
+                            'threshold': cli.threshold,
+                            'capacity': cli.capacity}
 
-    tree = MerkleTree(cli.dbfile, algorithm=cli.algorithm, **opts)
+    tree = MerkleTree(dbfile=cli.dbfile, algorithm=cli.algorithm, **opts)
 
     match cli.operation:
         case 'root':
             func = tree._get_root
 
-            def get_args():
-                return (cli.start, cli.limit)
+            def get_args() -> tuple[int, int]:  # type: ignore
+                return (int(cli.start), int(cli.limit))
 
             if cli.randomize:
-                def get_args():
-                    start = randint(0, cli.limit - 2)
-                    limit = randint(start + 1, cli.limit)
+                def get_args() -> tuple[int, int]:  # type: ignore
+                    start: int = randint(0, cli.limit - 2)
+                    limit: int = randint(start + 1, cli.limit)
 
                     return (start, limit)
 
         case 'state':
             func = tree.get_state
 
-            def get_args():
+            def get_args():  # type: ignore
                 return (cli.size,)
 
             if cli.randomize:
-                def get_args():
+                def get_args():  # type: ignore
                     size = randint(1, cli.size)
 
                     return (size,)
@@ -115,24 +116,24 @@ if __name__ == '__main__':
         case 'inclusion':
             func = tree.prove_inclusion
 
-            def get_args():
+            def get_args():  # type: ignore
                 return (cli.index, cli.size)
 
             if cli.randomize:
-                def get_args():
-                    size = cli.size
-                    index = randint(1, size)
+                def get_args():  # type: ignore
+                    size: int = cli.size
+                    index: int = randint(1, size)
 
                     return (index, size)
 
         case 'consistency':
             func = tree.prove_consistency
 
-            def get_args():
+            def get_args():  # type: ignore
                 return (cli.size1, cli.size2)
 
             if cli.randomize:
-                def get_args():
+                def get_args():  # type: ignore
                     size2 = cli.size2
                     size1 = randint(1, size2)
 
@@ -140,9 +141,9 @@ if __name__ == '__main__':
 
     count = 0
     while count < cli.rounds:
-        args = get_args()
+        args = get_args()  # type: ignore
         print('round %d:' % count, args)
-        func(*args)
+        func(*args)  # type: ignore
         count += 1
 
     print("\033[92m {}\033[00m".format(tree.get_cache_info()))

--- a/pymerkle/__init__.py
+++ b/pymerkle/__init__.py
@@ -1,8 +1,7 @@
 from .concrete.inmemory import InmemoryTree
 from .concrete.sqlite import SqliteTree
 from .core import BaseMerkleTree, InvalidChallenge
-from .proof import MerkleProof, verify_inclusion, verify_consistency, InvalidProof
-
+from .proof import InvalidProof, MerkleProof, verify_consistency, verify_inclusion
 
 __version__ = '6.1.0'
 

--- a/pymerkle/constants.py
+++ b/pymerkle/constants.py
@@ -2,12 +2,13 @@
 List of supported hash functions.
 """
 
-SHA2_ALGORITHMS = ['sha224', 'sha256', 'sha384', 'sha512']
-SHA3_ALGORITHMS = ['sha3_224', 'sha3_256', 'sha3_384', 'sha3_512']
-KECCAK_ALGORITHMS = ['keccak_224', 'keccak_256', 'keccak_384', 'keccak_512']
+SHA2_ALGORITHMS: list[str] = ['sha224', 'sha256', 'sha384', 'sha512']
+SHA3_ALGORITHMS: list[str] = ['sha3_224', 'sha3_256', 'sha3_384', 'sha3_512']
+KECCAK_ALGORITHMS: list[str] = ['keccak_224',
+                                'keccak_256', 'keccak_384', 'keccak_512']
 
 
-ALGORITHMS = SHA2_ALGORITHMS + SHA3_ALGORITHMS
+ALGORITHMS: list[str] = SHA2_ALGORITHMS + SHA3_ALGORITHMS
 try:
     import sha3
 except ImportError:

--- a/pymerkle/utils.py
+++ b/pymerkle/utils.py
@@ -1,4 +1,4 @@
-def log2(n):
+def log2(n: int) -> int:
     """
     Base 2 logarithm
 
@@ -9,7 +9,11 @@ def log2(n):
     :type n: int
     :rtype: int
     """
-    k = 0
+
+    if (n < 0):
+        raise ArithmeticError('n must be a non-negative integer')
+
+    k: int = 0
     while n >> 1:
         k += 1
         n >>= 1
@@ -17,7 +21,7 @@ def log2(n):
     return k
 
 
-def decompose(n):
+def decompose(n: int) -> list[int]:
     """
     Returns in respective order the exponents corresponding to the binary
     decomposition of the provided integer.
@@ -26,13 +30,16 @@ def decompose(n):
     :type n: int
     :rtype: list[int]
     """
-    exponents = []
+    if (n < 0):
+        raise ArithmeticError('n must be a non-negative integer')
 
-    i = 1
+    exponents: list[int] = []
+
+    i: int = 1
     while i < n + 1:
         if i & n:
-            p = -1
-            j = i
+            p: int = -1
+            j: int = i
             while j:
                 j >>= 1
                 p += 1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,8 @@ pytest-benchmark[histogram]>=3.4.1
 sphinx==4.4.0
 sphinx_rtd_theme>=1.0.0
 python-docs-theme
+autopep8>=2.0.4
+typing>=3.7.4.3
+typing_extensions>=4.8.0
+isort>=5.12.0
+cachetools>=5.3.1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,15 @@
 import itertools
+from typing import Final
+
 import pytest
-from pymerkle import constants, InmemoryTree, SqliteTree as _SqliteTree
 
+from pymerkle import InmemoryTree
+from pymerkle import SqliteTree as _SqliteTree
+from pymerkle import constants
 
-DEFAULT_MAXSIZE = 11
-DEFAULT_THRESHOLD = 2
-DEFAULT_CAPACITY = 1024 ** 3
+DEFAULT_MAXSIZE: Final[int] = 11
+DEFAULT_THRESHOLD: Final[int] = 2
+DEFAULT_CAPACITY: Final[int] = 1024 ** 3
 
 
 class SqliteTree(_SqliteTree):
@@ -14,8 +18,8 @@ class SqliteTree(_SqliteTree):
     used interchangeably
     """
 
-    def __init__(self, algorithm='sha256', **opts):
-        super().__init__(':memory:', algorithm, **opts)
+    def __init__(self, algorithm='sha256', **opts) -> None:
+        super().__init__(dbfile=':memory:', algorithm=algorithm, **opts)
 
     @classmethod
     def init_from_entries(cls, entries, algorithm='sha256', **opts):
@@ -25,32 +29,37 @@ class SqliteTree(_SqliteTree):
         return tree
 
 
-def pytest_addoption(parser):
+def pytest_addoption(parser) -> None:
     parser.addoption('--algorithm', default='sha256',
-        choices=constants.ALGORITHMS,
-        help='Hash algorithm to be used')
+                     choices=constants.ALGORITHMS,
+                     help='Hash algorithm to be used')
     parser.addoption('--extended', action='store_true', default=False,
-        help='Test against all supported hash algorothms')
+                     help='Test against all supported hash algorothms')
     parser.addoption('--backend', choices=['inmemory', 'sqlite'], default='inmemory',
-        help='Storage backend')
+                     help='Storage backend')
     parser.addoption('--maxsize', type=int, default=DEFAULT_MAXSIZE,
-        help='Maximum size of tree fixtures')
+                     help='Maximum size of tree fixtures')
     parser.addoption('--threshold', type=int, metavar='WIDTH',
-        default=DEFAULT_THRESHOLD,
-        help='Subroot cache threshold')
+                     default=DEFAULT_THRESHOLD,
+                     help='Subroot cache threshold')
     parser.addoption('--capacity', type=int, metavar='BYTES',
-        default=DEFAULT_CAPACITY,
-        help='Subroot cache capacity in bytes')
+                     default=DEFAULT_CAPACITY,
+                     help='Subroot cache capacity in bytes')
+
 
 option = None
 
-def pytest_configure(config):
+
+def pytest_configure(config) -> None:
     global option
     option = config.option
+    if option is None:
+        raise Exception('Option cannot be none')
 
 
 def all_configs(option):
-    algorithms = constants.ALGORITHMS if option.extended else [option.algorithm]
+    algorithms = constants.ALGORITHMS if option.extended else [
+        option.algorithm]
 
     configs = []
     for (disable_security, algorithm) in itertools.product((True, False), algorithms):
@@ -63,7 +72,7 @@ def all_configs(option):
     return configs
 
 
-def resolve_backend(option):
+def resolve_backend(option) -> type[SqliteTree] | type[InmemoryTree]:
     if option.backend == 'sqlite':
         return SqliteTree
 
@@ -72,21 +81,21 @@ def resolve_backend(option):
 
 def make_trees(default_config=False):
     configs = all_configs(option) if not default_config else [{'algorithm':
-        option.algorithm, 'disable_security': False}]
+                                                               option.algorithm, 'disable_security': False}]  # type: ignore
     MerkleTree = resolve_backend(option)
 
     return [MerkleTree.init_from_entries(
         [f'entry-{i}'.encode() for i in range(size)], **config)
-                               for size in range(0, option.maxsize + 1)
-                               for config in configs]
+        for size in range(0, option.maxsize + 1)  # type: ignore
+        for config in configs]
 
 
 def tree_and_index(default_config=False):
     return [(tree, index) for tree in make_trees(default_config)
-                          for index in range(1, tree.get_size() + 1)]
+            for index in range(1, tree.get_size() + 1)]
 
 
 def tree_and_range(default_config=False):
     return [(tree, start, limit) for tree in make_trees(default_config)
-                                 for start in range(0, tree.get_size())
-                                 for limit in range(start + 1, tree.get_size())]
+            for start in range(0, tree.get_size())
+            for limit in range(start + 1, tree.get_size())]


### PR DESCRIPTION
These changes require moving to Python 3.9 for `pymerkle` library. The `profiler` already required Python 3.10.

For details, see the vermin results:

```bash
$ vermin --target=3.7 --violations --backport argparse --backport typing --eval-annotations --no-parse-comments .\
Detecting python files..
Analyzing 28 files using 8 processes..
!2, 3.8      D:\Repos\pymerkle\benchmarks\conftest.py
  'typing.Final' member requires 2.7, 3.8
  final variable annotations require !2, 3.8

!2, 3.9      D:\Repos\pymerkle\benchmarks\init_db.py
  'typing.Final' member requires 2.7, 3.8
  builtin generic type annotation (dict[..]) requires !2, 3.9
  builtin generic type annotation (list[..]) requires !2, 3.9
  final variable annotations require !2, 3.8

!2, 3.9      D:\Repos\pymerkle\benchmarks\test_perf.py
  builtin generic type annotation (dict[..]) requires !2, 3.9

!2, 3.10     D:\Repos\pymerkle\profiler\__main__.py
  'typing.Final' member requires 2.7, 3.8
  builtin generic type annotation (dict[..]) requires !2, 3.9
  builtin generic type annotation (tuple[..]) requires !2, 3.9
  final variable annotations require !2, 3.8
  pattern matching requires !2, 3.10

!2, 3.9      D:\Repos\pymerkle\pymerkle\concrete\inmemory.py
  'typing.Literal' member requires 2.7, 3.8
  builtin generic type annotation (list[..]) requires !2, 3.9
  builtin generic type annotation (tuple[..]) requires !2, 3.9
  literal variable annotations require !2, 3.8

!2, 3.9      D:\Repos\pymerkle\pymerkle\concrete\sqlite.py
  builtin generic type annotation (list[..]) requires !2, 3.9
  builtin generic type annotation (tuple[..]) requires !2, 3.9

!2, 3.9      D:\Repos\pymerkle\pymerkle\constants.py
  builtin generic type annotation (list[..]) requires !2, 3.9

!2, 3.9      D:\Repos\pymerkle\pymerkle\core.py
  builtin generic type annotation (collections.deque[..]) requires !2, 3.9
  builtin generic type annotation (list[..]) requires !2, 3.9
  builtin generic type annotation (tuple[..]) requires !2, 3.9

!2, 3.8      D:\Repos\pymerkle\pymerkle\hasher.py
  'typing.Literal' member requires 2.7, 3.8
  literal variable annotations require !2, 3.8

!2, 3.9      D:\Repos\pymerkle\pymerkle\proof.py
  builtin generic type annotation (dict[..]) requires !2, 3.9
  builtin generic type annotation (list[..]) requires !2, 3.9
  builtin generic type annotation (tuple[..]) requires !2, 3.9

!2, 3.9      D:\Repos\pymerkle\pymerkle\utils.py
  builtin generic type annotation (list[..]) requires !2, 3.9

!2, 3.9      D:\Repos\pymerkle\tests\conftest.py
  'typing.Final' member requires 2.7, 3.8
  builtin generic type annotation (type[..]) requires !2, 3.9
  final variable annotations require !2, 3.8

Tips:
- You're using potentially backported modules: typing_extensions
  If so, try using the following for better results: --backport typing_extensions
(disable using: --no-tips)

Minimum required versions: 3.10
Incompatible versions:     2
Target versions not met:   3.7
```